### PR TITLE
question: Possible mistakes in example for RLE?

### DIFF
--- a/gcs_light_client.mediawiki
+++ b/gcs_light_client.mediawiki
@@ -162,7 +162,7 @@ As an example, consider the following sequence of bits:
 The RLE of the bit stream above would be:  
 
 <pre>
-1110 1001 0000 1111 0101 1111 1111 0000 0000 1011
+1110 1001 0000 1010 0000 1111 1111 0000 0000 1011
 </pre>
 
 RLE allows one to efficiently encode a data stream in a lossless manner. Due


### PR DESCRIPTION
When I validate your example for RLE by `python -c` as follows,

```
python3 -c 'print("{:b}".format(14))'
>>> 1110
python3 -c 'print("{:b}".format(9))' 
>>> 1001
python3 -c 'print("{:b}".format(0))' # this will be encoded as 0000
>>>> 0  
```
But I don't understand why `{0}^20` will be encoded as `1111 0101`
It doesn't supposed to be `1010 0000` ?

I don't fully understand this bip, or neither a specialist of encoding. So I may having very principle misunderstanding. I would appreciate if someone correct me.