### PR TITLE
Update bip-taro.mediawiki

### DIFF
--- a/bip-taro.mediawiki
+++ b/bip-taro.mediawiki
@@ -150,7 +150,7 @@ Provenance of an asset is proved using one of two mechanisms. The first of
 which, hence referred to as a "full proof" is a structured file that contains
 serialized proofs from an initial ''genesis output'', with a series of valid
 asset witnesses verifiably transferring ownership of an asset across taproot
-outputs. Full proofs are typically repented as a flat file for consumption,
+outputs. Full proofs are typically represented as a flat file for consumption,
 verification, display by the Taro protocol. 
 
 The second method of proving/verifying provenance is an MS-SMT of a slightly


### PR DESCRIPTION
Fix typo in "Asset Provenance" sections:

repented -> represented