### PR TITLE
multi: BIP taro wording, specificity, and typo fixes 

### DIFF
--- a/bip-taro-addr.mediawiki
+++ b/bip-taro-addr.mediawiki
@@ -49,10 +49,12 @@ Let the human readable prefix (as specified by BIP 173) be:
 * <code>taro</code> for mainnet
 * <code>tarot</code> for testnet
 
+We refer to this value as the <code>taro_hrp</code>
+
 Given the 32-byte <code>asset_id</code>, 32-byte
 <code>asset_script_key</code>, and 32-byte x-only BIP 340/341 internal public
 key, 8-byte amount to send, an address is encoded as:
-* <code>bech32(hrp=taroHrp, asset_id || asset_script_key || internal_key || amt)</code>
+* <code>bech32(hrp=taro_hrp, asset_id || asset_script_key || internal_key || amt)</code>
 
 ===Decoding and Sending To An Address===
 

--- a/bip-taro-ms-smt.mediawiki
+++ b/bip-taro-ms-smt.mediawiki
@@ -38,7 +38,7 @@ MS-SMT supports both non-inclusion proofs, and non-inflation proofs.
 
 A merkle sum tree is a merkalized key-value map simulated over a particia
 merkle tree of depth 256 (as we use sha256 as our hash function). The "base"
-state of the tree, is a merkle tree with 256 leaves, storing an "empty hash".
+state of the tree, is a merkle tree with 2^256 leaves, storing an "empty hash".
 Within this tree, the digests of an empty leaf, and empty internal nodes for
 each level can be computed ahead of time. The "value" of an empty leaf is zero.
 
@@ -102,7 +102,7 @@ next bit position of the key itself. We assume the existence of a persistent
 key-value store that maps the hash of a node to the left and right digests of
 its children.
 
-The following routine specifies the insertion algorithm:
+The following routine specifies the lookup algorithm:
 <source lang="python">
 lookup_item(key [32]byte, db KVStore) -> MerkleSumLeaf:
 

--- a/bip-taro-vm.mediawiki
+++ b/bip-taro-vm.mediawiki
@@ -56,14 +56,25 @@ commitment (which lives in a taproot output), and its valid opening, the set
 the previous asset ID are compressed into a single input, and the present
 <code>split_commitment</code> is used to compress the output state.
 
+State transition validation may take one or two asset leaves within a single
+transaction (with the leaves living in different outputs). When a single leaf
+is present, no splits occurred in the state transition, or the asset is a
+collectible. When two leaves are specified, then one of the leaves was a split
+resulting from a split event at the Taro layer. In this case, the split
+commitment proof, as well as the validity of the state transition creating the
+splits are validated.
+
+
 ====Mapping Inputs====
+
+Input mapping is only executed for state transitions that specify
+<code>prev_asset_witnesses</code>.
 
 Given a set of inputs, each identified by a <code>prev_asset_id</code>, the
 input commitment (which is used as the previous output) is constructed as
 follows:
 
 # Initialize a new empty MS-SMT tree as specified in [[../master/bip-taro-ms-smt.mediawiki|bip-taro-ms-smt]].
-# If the Taro output to be validated only specifies a <code>split_commitment</code>, then the <code>prev_asset_witnesses</code> of the referenced root output are used in place.
 # For each Taro input ''c_i'', identified in the <code>prev_asset_witnesses</code> field:
 ## Serialize the referenced previous asset leaf (identified by <code>prev_outpoint || asset_id || asset_script_hash</code>) in TLV format.
 ## Insert this leaf into the MS-SMT tree, with a key of the <code>prev_id_identifier</code>, a value of the serialized leaf, and sum value of the asset amount contained in the leaf.
@@ -80,29 +91,37 @@ verification, as there may be multiple input witnesses, during validation, the
 
 ====Mapping Outputs====
 
+Output mapping is only executed for state transitions that specify
+<code>prev_asset_witnesses</code>.
+
 Given a Taro output, and any associated outputs contained within its
 <code>split_commitment_root</code>, the output commitment is constructed as
 follows:
 
-# If the Taro output to be validated includes a
 # Let the output value be the sum of all the <code>amt</code> fields on the top level as well as the split commitment cohort set, in other words the last 4-bytes of the <code>split_commitment_root</code>.
 # Let the output script be the first 32-bytes of the <code>split_commitment_root</code> value converted to a segwit v1 witness program (taproot).
 
 ====Validating a State Transition====
 
-Once the set of inputs and outputs have been mapped to our virtual Bitcoin
+If a state transition specifies a <code>prev_asset_witnesses</code> field, then
+once the set of inputs and outputs have been mapped to our virtual Bitcoin
 transaction (creating a v2 Bitcoin transaction with a single input and output),
 validation proceeds as normal according to BIP 341+342 with the following
 modifications:
 
+
 # If the <code>input_asset_sum</code> is not exactly equal to the <code>output_asset_sum</code> validation MUST fail.
-# If the Taro output to be validated only specifies a <code>split_commitment_root</code> and no explicit inputs, then a valid inclusion proof for the output MUST be presented and valid.
 # The previous public key script for each input is to be the <code>asset_script_hash</code> for each previous input, mapped to a v1 segwit witness program (taproot).
 # The input value for each included input is to be the <code>amt</code> field of the previous Taro output being spent.
 # All signatures included in the witness MUST be exactly 64-bytes in length, which triggers <code>SIGHASH_DEFAULT</code> evaluation.
 # If the <code>prev_asset_id</code> is blank, then ALL witnesses MUST be blank as well and the <code>prev_outpoint</code> values as well. In this case, verification succeeds as this is only a creation/minting transaction.
 # If the <code>asset_id</code> value is NOT the same for each Taro input and output, validation MUST fail.
 ## Alternatively, if each input and output has the same referenced <code>asset_family_key</code>, then only the <code>asset_tags</code> MUST match.
+
+Otherwise, if a state transition only specifies a <code>split_commitment_proof<code>, then:
+# If the Taro output to be validated only specifies a <code>split_commitment_proof</code> and no explicit inputs, then a valid inclusion proof for the output MUST be presented and valid.
+## If the proof is invalid, then validation MUST fail.
+# Given the "parent" split, execute the input+output mapping and verify the state transition using the logic above.
 
 (TODO(roasbeef): lift the sighash requirement here? useful for swappy stuff??)
 

--- a/bip-taro.mediawiki
+++ b/bip-taro.mediawiki
@@ -208,13 +208,13 @@ asset ID. A given Taro asset tree is composed of two nested MS-SMT instances:
 # The first level maps an <code>asset_id</code> or <code>asset_key_family</code> to a sub-tree root hash of a given asset.
 # The second level maps an <code>asset_script_key</code> or <code>asset_id || asset_script_key</code> to a serialized Taro asset leaf.
 
-The root hash of an asset leaf, observing [[../master/bip-0341.mediawiki|BIP-341]] is
+The root hash of an asset tree, observing [[../master/bip-0341.mediawiki|BIP-341]] is
 represented as a Tapscript tree with a single leaf:
 * <code>tagged_hash("TapLeaf", leaf_version || taro_version || asset_tree_root)</code>
 
 A <code>leaf_version</code> of ??? is selected. From the PoV of the Bitcoin
 system, we've simply committed to a tapscript leaf with an unparseable Script.
-In the future, if the Bitcoin system is soft forked to gain awayness of the
+In the future, if the Bitcoin system is soft forked to gain awareness of the
 Taro-specific commitments, then the same or different leaf version can be used
 to gate verification of the new behavior.
 
@@ -240,7 +240,7 @@ Instead to ensure locally unique <code>asset_id</code> instances within initial
 asset creation, each <code>asset_tag</code> and <code>asset_meta</code> value
 MUST only appear once during asset creation.
 
-The top-level MS-SMT commits to set of all held defined assets. The root hash
+The top-level MS-SMT commits to the set of all held defined assets. The root hash
 of this MS-SMT tree is referred to as the <code>asset_tree_root</code>. The
 MS-SMT is structured as follows:
 * key: <code>asset_id</code> or <code>asset_key_family</code>
@@ -343,15 +343,15 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 ******* value: [<code>...*byte</code>:<code>asset_witness</code>]
 ****** type: 2 (<code>split_commitment_proof</code>)
 ******* value: [<code>...*byte</code>:<code>split_proof</code>]
-* type: 1 (<code>split_commitment</code>)
+* type: 5 (<code>split_commitment</code>)
 ** value: [<code>32*byte</code>:<code>split_commitment_root</code>]
-* type: 5 (<code>asset_script_version</code>)
+* type: 6 (<code>asset_script_version</code>)
 ** value: 
 *** [<code>u16</code>:<code>script_version</code>]
-* type: 6 (<code>asset_script_key</code>)
+* type: 7 (<code>asset_script_key</code>)
 ** value: 
 *** [<code>33*byte</code>:<code>pub_key</code>]
-* type: 7 (<code>asset_family_key</code>)
+* type: 8 (<code>asset_family_key</code>)
 ** value: 
 *** [<code>96*byte</code>:<code>pub_key || schnorr_sig</code>]
 
@@ -400,16 +400,15 @@ Verification logic for <code>asset_script_version</code> is fully defined in
 BIP ???. In the future new asset script versions can be introduced to further
 increase the expressibility of the embedded asset script.
 
-TLV types below 2^16-1 are reserved for use by additional `taro_version`
-interations. Types with a numerical value above this reserved range can be used
-TLV types below 2^16-1 are reserved for use by additional
-<code>taro_version</code> iterations. Types with a numerical value above this
-reserved range can be used to store arbitrary attributes to assets. An eaxmple
-of such an attribute would be storing the _mutable_ stats of an in-game asset.
-Any immutable fields for normal or collectible assets should be instead
-committed to within the `asset_meta` be storing the ''mutable'' stats of an
-in-game asset. Any immutable fields for normal or unique assets should be
-instead committed to within the <code>asset_meta</code> field.
+Types with a numerical value above this reserved range can be used TLV types
+below 2^16-1 are reserved for use by additional <code>taro_version</code>
+iterations. Types with a numerical value above this reserved range can be used
+to store arbitrary attributes to assets. An eaxmple of such an attribute would
+be storing the _mutable_ stats of an in-game asset.  Any immutable fields for
+normal or collectible assets should be instead committed to within the
+`asset_meta` be storing the ''mutable'' stats of an in-game asset. Any
+immutable fields for normal or unique assets should be instead committed to
+within the <code>asset_meta</code> field.
 
 The usage of an MS-SMT for the Taro asset tree itself permits parties to easily
 verify that no new assets are created when inputs are referenced, and also that
@@ -838,7 +837,7 @@ Assuming Bob has <code>N</code> beefbux of outbound liquidity, and Alice has
 <code>M</code> beefbux of inbound liquidity (where <code>N>M</code>) then Bob
 can send <code>M</code> beefbux to Alice. The first hop of the transfer takes
 in <code>M+f</code> beefbux (where <code>f</code> is their fee) and sends out
-<code>K = M/B</code> BTC, where <code>code</code> is the agreed/advertised
+<code>K = M/B</code> BTC, where <code>B</code> is the agreed/advertised
 beefbux/BTC exchange rate. All final hop of the transfer takes in
 <code>K</code> BTC and sends <code>M</code> beefbuf (in the actual route this
 would be less due to fees) to Alice.


### PR DESCRIPTION
Implements a series of changes driven by comments by @t-bast on a prior commit/version. 

Most of them are typo fixes, but the most important one is tightening of the specification when it comes to validating an asset that is the result of an asset split state transition (you need to verify the split commitment and also the parent's state transition). 
