### PR TITLE
bip-taro-vm: address ambiguities in spec brought up during implementation 

### DIFF
--- a/bip-taro-vm.mediawiki
+++ b/bip-taro-vm.mediawiki
@@ -79,15 +79,38 @@ follows:
 ## Serialize the referenced previous asset leaf (identified by <code>prev_outpoint || asset_id || asset_script_hash</code>) in TLV format.
 ## Insert this leaf into the MS-SMT tree, with a key of the <code>prev_id_identifier</code>, a value of the serialized leaf, and sum value of the asset amount contained in the leaf.
 # Obtain the root hash <code>input_root</code> and sum value <code>input_asset_sum</code> resulting from the tree creation and root digest computation.
-# Let the hash of the serialized 36-byte MS-SMT root be the sole previous output of the virtual execution transaction.
-# A value of zero is used for the output index of the virtual execution transaction.
+# Let the hash of the serialized 36-byte MS-SMT root be the sole previous outpoint (the txid) of the virtual execution transaction.
 
 With the above routine, we map the input set into a MS-SMT tree, which also
 commits to the total amount being spent of any given asset. During
 verification, as there may be multiple input witnesses, during validation, the
 <code>asset_witness</code> for each input is used as the initial witness stack.
 
-(TODO(roasbeef): need to map the squence number as well?)
+Notice that we don't map the <code>relative_lock_time</code> field here within
+this unified input commitment. Instead we'll map this during the
+verification/signing process, which enables the existence of per-input relative
+and absolute lock time.
+
+The following algorithm implements the input mapping required for full state
+transition verification:
+<source lang="python">
+make_virtual_input(prev_inputs: map[PrevOut]TaroLeaf) -> (MerkleSumRoot, TxIn):
+    input_smt = new_ms_smt()
+
+    for prev_out, taro_leaf in prev_inputs:
+        leaf_bytes = taro_leaf.serialize_tlv()
+
+        input_smt.insert(key=prev_out, value=leaf_bytes, sum_value=taro_leaf.amt)
+
+    input_root = input_smt.root()
+
+    virtual_txid = sha256(input_root.hash || input_root.sum_value)
+
+    # We only only bind the virtual txid here. Below we'll modify the input
+    # index based on the ordering of this SMT.
+    return input_root, NewTxIn(NewOutPoint(txid=virtual_txid), nil)
+        
+</source>
 
 ====Mapping Outputs====
 
@@ -98,8 +121,45 @@ Given a Taro output, and any associated outputs contained within its
 <code>split_commitment_root</code>, the output commitment is constructed as
 follows:
 
-# Let the output value be the sum of all the <code>amt</code> fields on the top level as well as the split commitment cohort set, in other words the last 4-bytes of the <code>split_commitment_root</code>.
-# Let the output script be the first 32-bytes of the <code>split_commitment_root</code> value converted to a segwit v1 witness program (taproot).
+# For normal asset transfers:
+## Let the output value be the sum of all the <code>amt</code> fields on the top level as well as the split commitment cohort set, in other words the last 4-bytes of the <code>split_commitment_root</code>.
+## Let the output script be the first 32-bytes of the <code>split_commitment_root</code> value converted to a segwit v1 witness program (taproot).
+
+# For collectible asset transfers
+## Let the output value be exactly ''1'' (as each TLV leaf related to a collectible can only ever transfer that same collectible to another leaf).
+## Let the output script be the first 32-bytes of an MS-SMT tree with a single element of the serialized TLV leaf of the collectible. 
+### The key for this single value is <code>sha256(asset_key_family || asset_id || asset_script_key)</code>. If a <code>asset_key_family</code> field isn't specified, then 32-bytes of zeroes should be used in place.
+
+The following algorithm implements the output mapping required for full state
+transition verification:
+<source lang="python">
+make_virtual_txout(leaf: TaroLeaf) -> (MerkleSumRoot, TxOut):
+    match leaf.asset_type:
+        case Normal:
+            tx_out = NewTxOut(
+                pk_script=[OP_1 OP_DATA_32 leaf.split_commitment_root.hash], 
+                value=leaf.split_commitment_root.sum_value,
+            )
+
+            return leaf.split_commitment_root, tx_out
+
+        case Collectible:
+            output_smt = new_ms_smt()
+            output_smt.insert(
+                key=sha256(leaf.asset_key_family || leaf.asset_id || leaf.asset_script_key)
+                value=leaf.serialize_tlv(),
+                sum_value=1,
+            )
+
+            witness_program = output_smt.root_hash()
+
+            tx_out = NewTxOut(
+                pk_script=[OP_1 OP_DATA_32 witness_program], 
+                value=1,
+            )
+
+            return output_smt.root, tx_out
+</source>
 
 ====Validating a State Transition====
 
@@ -109,23 +169,103 @@ transaction (creating a v2 Bitcoin transaction with a single input and output),
 validation proceeds as normal according to BIP 341+342 with the following
 modifications:
 
-
 # If the <code>input_asset_sum</code> is not exactly equal to the <code>output_asset_sum</code> validation MUST fail.
-# The previous public key script for each input is to be the <code>asset_script_hash</code> for each previous input, mapped to a v1 segwit witness program (taproot).
-# The input value for each included input is to be the <code>amt</code> field of the previous Taro output being spent.
-# All signatures included in the witness MUST be exactly 64-bytes in length, which triggers <code>SIGHASH_DEFAULT</code> evaluation.
-# If the <code>prev_asset_id</code> is blank, then ALL witnesses MUST be blank as well and the <code>prev_outpoint</code> values as well. In this case, verification succeeds as this is only a creation/minting transaction.
-# If the <code>asset_id</code> value is NOT the same for each Taro input and output, validation MUST fail.
-## Alternatively, if each input and output has the same referenced <code>asset_family_key</code>, then only the <code>asset_tags</code> MUST match.
+# For each <code>prev_input</code> within the set of referenced <code>prev_asset_witnesses</code>:
+## If the <code>asset_type</code> of the referenced input leaf doesn't map the <code>asset_type</code> of the Taro leaf spending the input, validation MUST fail.
+## Construct a single-input-single-output Bitcoin transaction based on the input and output mapping above.
+### The prev out input index should be the lexicographical index of the <code>prev_id_identifier</code> field for each input.
+### The previous public key script should be the <code>asset_script_hash</code> for the current previous input, mapped to a v1 segwit witness program (taproot).
+### The input value for each included input is to be the <code>amt</code> field of the previous Taro output being spent.
+### Set the sequence number to the <code>relative_lock_time</code> field of the input, if it exists.
+## Set the lock time of the transaction as the <code>lock_time</code> of the input TLV leaf being validated, if it exists.
+## All signatures included in the witness MUST be exactly 64-bytes in length, which triggers <code>SIGHASH_DEFAULT</code> evaluation.
+## If the <code>prev_asset_id</code> is blank, then ALL witnesses MUST be blank as well and the <code>prev_outpoint</code> values as well. In this case, verification succeeds as this is only a creation/minting transaction.
+## If the <code>asset_id</code> value is NOT the same for each Taro input and output, validation MUST fail.
+### Alternatively, assert that each input and output references the same <code>asset_family_key</code> field.
+## Perform external lock time and relative lock time validation:
+### If a <code>relative_lock_time</code> field exists, if the input age of the referenced TLV leaf is less than <code>relative_lock_time</code> validation MUST fail.
+### If a <code>lock_time</code> field exists, if the block height of the block that includes the transaction is less than <code>lock_time</code> validation MUST fail.
+## Validate the transaction according to the BIP 341+342 rules.
 
-Otherwise, if a state transition only specifies a <code>split_commitment_proof<code>, then:
+We explicitly implement lock time semantics at this level, as the sequence and
+lock time fields in the context of Bitcoin itself are validated from the PoV of
+connecting a new block to the end of the main chain. 
+
+Otherwise, if a state transition only specifies a <code>split_commitment_proof</code>, then:
 # If the Taro output to be validated only specifies a <code>split_commitment_proof</code> and no explicit inputs, then a valid inclusion proof for the output MUST be presented and valid.
 ## If the proof is invalid, then validation MUST fail.
 # Given the "parent" split, execute the input+output mapping and verify the state transition using the logic above.
 
-(TODO(roasbeef): lift the sighash requirement here? useful for swappy stuff??)
+The following algorithm implements verification for top level Taro leaves, as
+well leaves created via split commitments:
+<source lang="python">
+verify_taro_state_transition(leaf: TaroLeaf, leaf_split: TaroLeaf) -> bool
+    if is_valid_issuance_txn(leaf):
+        return true
 
-(TODO(roasbeef): split commitment root as another control block??)
+    if leaf_split is not None:
+        if leaf is None:
+            return false
+
+        if !verify_split_commitment(leaf.split_commitment_root, 
+            leaf_split.split_commitment_proof):
+
+            return false
+
+    input_smt, tx_in = make_virtual_input(leaf.prev_inputs)
+    output_smt, tx_out =  make_virtual_txout(leaf)
+
+    if input_smt.sum_value != output_smt.sum_value:
+        return false
+
+    virtual_tx_template = NewTx([tx_in], [tx_out])
+    for input in range leaf.prev_inputs:
+       if input.asset_type != leaf.asset_type:
+           return false
+       
+       match input.asset_id:
+          case AssetID:
+              if input.asset_id != leaf.asset_id:
+                  return false
+          case KeyFamily:
+              if input.asset_key_family != leaf.asset_key_family:
+                  return false
+
+       virtual_tx = virtual_tx_template.clone()
+
+       if !parse_valid_schnorr_sigs(input.asset_witness):
+           return false
+
+       virtual_tx.tx_in[0].witness = input.asset_witness
+       virtual_tx.tx_in[0].prev_out.index = input_smt.leaf_index_of(input)
+
+       prev_pk_script = OP_1 OP_DATA_32 input.asset_script_key
+       input_value = input.amt
+
+       if input.relative_lock_time != 0:
+           virtual_tx.tx_in[0].sequence = relative_lock_time
+
+           input_age = conf_input_age(input)
+           if num_confs(input) < input_age:
+               return false
+
+       if input.lock_time != 0:
+           virtual_tx.lock_time = leaf.lock_time
+
+           block_height = env.block_height()
+           if block_height < virtual_tx.lock_time:
+               return false
+
+       vm = new_script_vm(
+           prev_pk_script=prev_pk_script, tx=virtual_tx, input_index=0, 
+           input_amt=input_value,
+       )
+
+       if !vm.Execute():
+           return false
+
+    return true
+</source>
 
 ==Test Vectors==
 

--- a/bip-taro.mediawiki
+++ b/bip-taro.mediawiki
@@ -464,10 +464,13 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 * type: 3 (<code>amt</code>)
 ** value: 
 *** [<code>BigSize</code>:<code>amt</code>]
-* type: 3 (<code>lock_time</code>)
+* type: 4 (<code>lock_time</code>)
 ** value: 
 *** [<code>BigSize</code>:<code>block_height</code>]
-* type: 4 (<code>prev_asset_witnesses</code>)
+* type: 5 (<code>relative_lock_time</code>)
+** value: 
+*** [<code>BigSize</code>:<code>num_relative_blocks</code>]
+* type: 6 (<code>prev_asset_witnesses</code>)
 ** value: 
 *** [<code>u16</code>:<code>num_inputs</code>][<code>asset_witnesses...</code>], where:
 **** [<code>...*byte</code>:<code>asset_witnesses</code>]:
@@ -478,15 +481,15 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 ******* value: [<code>...*byte</code>:<code>asset_witness</code>]
 ****** type: 2 (<code>split_commitment_proof</code>)
 ******* value: [<code>...*byte</code>:<code>split_proof</code>]
-* type: 5 (<code>split_commitment</code>)
+* type: 7 (<code>split_commitment</code>)
 ** value: [<code>32*byte</code>:<code>split_commitment_root</code>]
-* type: 6 (<code>asset_script_version</code>)
+* type: 8 (<code>asset_script_version</code>)
 ** value: 
 *** [<code>u16</code>:<code>script_version</code>]
-* type: 7 (<code>asset_script_key</code>)
+* type: 9 (<code>asset_script_key</code>)
 ** value: 
 *** [<code>33*byte</code>:<code>pub_key</code>]
-* type: 8 (<code>asset_family_key</code>)
+* type: 10 (<code>asset_family_key</code>)
 ** value: 
 *** [<code>96*byte</code>:<code>pub_key || schnorr_sig</code>]
 
@@ -499,6 +502,7 @@ where:
 ** <code>1</code>: a collectible asset
 * <code>amt</code>: is the amount of the asset held in this leaf position
 * <code>lock_time</code>: is a field that restricts ''when'' an asset can be moved based on the included block height.
+* <code>relative_lock_time</code>: is a field that restricts ''when'' an asset can be moved based on a number of blocks that needs to passed from the mining of the outer transaction.
 * <code>prev_asset_witnesses</code>: is a ''nested'' TLV that contains the asset witnesses needed to verify the merging into the target asset leaf
 ** <code>prev_asset_id</code>: references the previous asset input by the input position within the transaction, the asset ID of the previous asset tree, and the asset script hash.
 *** This value is included in any signatures generated within the asset witness itself, serving a purpose similar to the previous outpoint in vanilla Bitcoin.


### PR DESCRIPTION
In this PR we make a series of changes to address ambiguities in the spec brought up during on going implementation. First, we address an existing TODO by explicitly creating a relative lock time field in the main asset TLV leaf. Next we make the VM verification more explicitly by enumerating each field that needs to be mapped to the virtual transaction format, and also lifting the relative+absolute lock time validation to this level as those checks are typically during mempool/block validation. 