### PR TITLE
Provide group key derivation at genesis proof

### DIFF
--- a/bip-tap-proof-file.mediawiki
+++ b/bip-tap-proof-file.mediawiki
@@ -57,8 +57,7 @@ with verification halting if an invalid state transition or proof is
 encountered.
 
 A file is a series of inclusion and state transition proofs rooted at a given
-genesis outpoint. The very first transition requires no witness validation as
-its the genesis outpoint. 
+genesis outpoint.
 
 ====File Serialization====
 

--- a/bip-tap-proof-file.mediawiki
+++ b/bip-tap-proof-file.mediawiki
@@ -147,6 +147,9 @@ blob with the following format:
 *** [<code>metadata_len*byte</code>:<code>metadata</code>]
 *** [<code>u32</code>:<code>output_index</code>]
 *** [<code>u8</code>:<code>type</code>]
+* type: 13 (<code>asset_group_key_reveal</code>)
+** value: 
+*** [<code>64*byte</code>:<code>pub_key || asset_group_script_root</code>]
 
 where:
 * <code>version</code>: is the version of the single mint or transition proof, currently fixed to value <code>0</code>.
@@ -174,6 +177,11 @@ where:
 * <code>block_height</code>: is the block height of the block that includes a spend of the <code>prev_out</code> outpoint.
 * <code>asset_genesis</code>: is a mandatory field for genesis assets. The <code>asset_genesis</code> represents the preimage of the <code>asset_id</code>.
 ** This field MUST only be present for genesis asset proofs.
+* <code>asset_group_key_reveal</code>: is a mandatory field (for genesis assets having a group key) that reveals the raw internal signing key and script root needed to derive the asset group key: <code>asset_raw_group_key = asset_group_key_reveal[0:32]</code>, <code>asset_group_script_root = asset_group_key_reveal[32:64]</code>.
+** <code>asset_raw_group_key</code>: is a 32-byte public key as defined by [[../master/bip-0340.mediawiki|BIP-340]]. The raw public key is revealed at genesis in order for verifiers to to check the group key derivation. The owner of the corresponding private key is able to sign for the group key using the key spend path when minting an asset.
+** <code>asset_group_script_root</code>: is a 32-byte tapscript root as defined by [[../master/bip-0341.mediawiki|BIP-341]]. The root is revealed at genesis in order for verifiers to to check the group key derivation. The root can hold arbitrary scripts that enforces conditions for minting the asset. 
+** If the contained asset is a genesis asset (has a valid genesis witness), then a verifier SHOULD verify that: <code>asset_group_key == GroupKey(asset_id, asset_raw_group_key, asset_group_script_root)</code> according to [bip-tap].
+** This field MUST only be present for genesis asset proofs having a group key.
 
 The final flat proof file has the following format:
 * [<code>u32</code>:<code>file_version</code>] version of proof file format, currently fixed to <code>0</code>.

--- a/bip-tap-proof-file.mediawiki
+++ b/bip-tap-proof-file.mediawiki
@@ -137,6 +137,16 @@ blob with the following format:
 * type: 12 (<code>block_height</code>)
 ** value:
 *** [<code>uint32</code>:<code>block_height</code>]
+* type: 12 (<code>asset_genesis</code>)
+** value:
+*** [<code>32*byte</code>:<code>first_prev_out_hash</code>]
+*** [<code>u32</code>:<code>first_prev_out_index</code>]
+*** [<code>BigSize</code>:<code>tag_len</code>]
+*** [<code>tag_len*byte</code>:<code>tag</code>]
+*** [<code>BigSize</code>:<code>metadata_len</code>]
+*** [<code>metadata_len*byte</code>:<code>metadata</code>]
+*** [<code>u32</code>:<code>output_index</code>]
+*** [<code>u8</code>:<code>type</code>]
 
 where:
 * <code>version</code>: is the version of the single mint or transition proof, currently fixed to value <code>0</code>.
@@ -162,6 +172,8 @@ where:
 *** This field MUST only be present for genesis asset proofs.
 * <code>challenge_witness</code> is an optional asset witness over a well-defined asset state transition that proves ownership of the <code>script_key</code> the asset currently resides at.
 * <code>block_height</code>: is the block height of the block that includes a spend of the <code>prev_out</code> outpoint.
+* <code>asset_genesis</code>: is a mandatory field for genesis assets. The <code>asset_genesis</code> represents the preimage of the <code>asset_id</code>.
+** This field MUST only be present for genesis asset proofs.
 
 The final flat proof file has the following format:
 * [<code>u32</code>:<code>file_version</code>] version of proof file format, currently fixed to <code>0</code>.

--- a/bip-tap-vm.mediawiki
+++ b/bip-tap-vm.mediawiki
@@ -73,14 +73,14 @@ transition creating the splits are validated.
 Input mapping is only executed for state transitions that specify
 <code>prev_asset_witnesses</code>.
 
-Given a set of inputs, each identified by a <code>prev_asset_id</code>, the
+Given a set of inputs, each identified by a <code>prev_asset_input</code>, the
 input commitment (which is used as the previous output) is constructed as
 follows:
 
 # Initialize a new empty MS-SMT tree as specified in [[./bip-tap-ms-smt.mediawiki|bip-tap-ms-smt]].
 # For each Taproot Asset input ''c_i'', identified in the <code>prev_asset_witnesses</code> field:
 ## If the asset input has a <code>split_commitment</code> in the witness, that needs to be removed before the serialization step.
-## Serialize the referenced previous asset leaf (identified by <code>prev_outpoint || asset_id || asset_script_hash</code>) in TLV format.
+## Serialize the referenced previous asset leaf (identified by <code>prev_outpoint || prev_asset_id || prev_asset_script_key</code>) in TLV format.
 ## Insert this leaf into the MS-SMT tree, with a key of the <code>prev_id_identifier</code>, a value of the serialized leaf, and sum value of the asset amount contained in the leaf.
 # Obtain the root hash <code>input_root</code> and sum value <code>input_asset_sum</code> resulting from the tree creation and root digest computation.
 # Let the hash of the serialized 36-byte MS-SMT root be the sole previous outpoint (the txid) of the virtual execution transaction.
@@ -178,7 +178,7 @@ modifications:
 ## If the <code>asset_type</code> of the referenced input leaf doesn't map the <code>asset_type</code> of the Taproot Asset leaf spending the input, validation MUST fail.
 ## Construct a single-input-single-output Bitcoin transaction based on the input and output mapping above.
 ### The prev out input index should be the lexicographical index of the <code>prev_id_identifier</code> field for each input.
-### The previous public key script should be the <code>asset_script_hash</code> for the current previous input, mapped to a v1 segwit witness program (taproot).
+### The previous public key script should be the <code>asset_script_key</code> for the current previous input, mapped to a v1 segwit witness program (taproot).
 ### The input value for each included input is to be the <code>amt</code> field of the previous Taproot Asset output being spent.
 ### Set the sequence number to the <code>relative_lock_time</code> field of the input, if it exists.
 ## Set the lock time of the transaction as the <code>lock_time</code> of the input TLV leaf being validated, if it exists.

--- a/bip-tap-vm.mediawiki
+++ b/bip-tap-vm.mediawiki
@@ -81,6 +81,10 @@ follows:
 # For each Taproot Asset input ''c_i'', identified in the <code>prev_asset_witnesses</code> field:
 ## If the asset input has a <code>split_commitment</code> in the witness, that needs to be removed before the serialization step.
 ## Serialize the referenced previous asset leaf (identified by <code>prev_outpoint || prev_asset_id || prev_asset_script_key</code>) in TLV format.
+### For a minting transaction, a copy of the output leaf with emptied <code>prev_asset_witnesses</code> is used, in addition to these modifications:
+#### If the minted asset has a group key, the <code>asset_script_key</code> of the copied leaf should be set equal to the group key. This enforces that the state transition verification uses the group key when validating the spend.
+#### If the asset has no group key, the <code>asset_script_key</code> field should be blank. This will short-circuit the state transition verification, allowing minting an asset that does not support emission.
+### This is to ensure we can get a complete virtual tx mapping also for minting transactions.
 ## Insert this leaf into the MS-SMT tree, with a key of the <code>prev_id_identifier</code>, a value of the serialized leaf, and sum value of the asset amount contained in the leaf.
 # Obtain the root hash <code>input_root</code> and sum value <code>input_asset_sum</code> resulting from the tree creation and root digest computation.
 # Let the hash of the serialized 36-byte MS-SMT root be the sole previous outpoint (the txid) of the virtual execution transaction.
@@ -183,7 +187,7 @@ modifications:
 ### Set the sequence number to the <code>relative_lock_time</code> field of the input, if it exists.
 ## Set the lock time of the transaction as the <code>lock_time</code> of the input TLV leaf being validated, if it exists.
 ## All signatures included in the witness MUST be exactly 64-bytes in length, which triggers <code>SIGHASH_DEFAULT</code> evaluation.
-## If the <code>prev_asset_id</code> is blank, then ALL witnesses MUST be blank as well and the <code>prev_outpoint</code> values as well. In this case, verification succeeds as this is only a creation/minting transaction.
+## If the <code>asset_script_key</code> is blank, then the <code>asset_group_key</code> MUST be blank, and ALL witnesses MUST be blank. In this case, verification succeeds as this is only a creation/minting transaction for an asset without emission.
 ## If the <code>asset_id</code> value is NOT the same for each Taproot Asset input and output, validation MUST fail.
 ### Alternatively, assert that each input and output references the same <code>asset_family_key</code> field.
 ## Perform external lock time and relative lock time validation:
@@ -204,7 +208,7 @@ The following algorithm implements verification for top level Taproot Asset
 leaves, as well leaves created via split commitments:
 <source lang="python">
 verify_taproot_asset_state_transition(leaf: TaprootAssetLeaf, leaf_split: TaprootAssetLeaf) -> bool
-    if is_valid_issuance_txn(leaf):
+    if is_valid_issuance_txn_no_group_key(leaf):
         return true
 
     if leaf_split is not None:

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -394,9 +394,8 @@ MS-SMT is structured as follows:
 * sum_value: <code>asset_sum</code>
 
 Similar to the <code>asset_id</code>, the <code>asset_group_key</code> is
-derived using the first input outpoint as a sort of chain randomness to ensure
-uniqueness within the system as well as the output index and asset type to
-prevent collisions.
+derived in a way that ensures uniqueness within the system, but can be shared
+between more than a single asset mint.
 The <code>asset_group_key</code> is derived as follows:
 * <code>asset_group_key = TapTweak(asset_internal_group_key, asset_group_script_root)</code>
 
@@ -404,6 +403,7 @@ where:
 * <code>asset_raw_group_key</code> is a 32-byte public key as defined by [[../master/bip-0340.mediawiki|BIP-340]]
 * <code>asset_internal_group_key = SingleTweak(asset_raw_group_key, asset_id)</code> 
 * <code>asset_group_script_root</code> is a taproot that can hold arbitrary asset scripts enforcing conditions for minting the asset.
+** <code>asset_raw_group_key</code> and <code>asset_group_script_root</code> must be revealed at asset genesis in order to verify the group key, and hence will be provided with the asset proof.
 
 and
 * <code>TapTweak</code> is the taproot tweak function as defined in [[../master/bip-0341.mediawiki|BIP-341]]. 

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -398,18 +398,17 @@ derived using the first input outpoint as a sort of chain randomness to ensure
 uniqueness within the system as well as the output index and asset type to
 prevent collisions.
 The <code>asset_group_key</code> is derived as follows:
-* <code>asset_group_key</code> = <code>asset_key_internal +
-sha256(asset_key_internal || genesis_outpoint || output_index || asset_type)
-</code>
+* <code>asset_group_key = TapTweak(asset_internal_group_key, asset_group_script_root)</code>
 
 where:
-* <code>asset_key_internal</code> is a 32-byte public key as defined by
-[[../master/bip-0340.mediawiki|BIP-340]]
-* <code>genesis_outpoint</code> is the first previous input outpoint used in the
-asset genesis transaction serialized in Bitcoin wire format.
-* <code>output_index</code> (4 byte, big-endian) is the index  of the output
-which contains the unique Taproot Asset commitment in the genesis transaction. 
-* <code>asset_type</code> (1 byte) is the type of the asset being minted.
+* <code>asset_raw_group_key</code> is a 32-byte public key as defined by [[../master/bip-0340.mediawiki|BIP-340]]
+* <code>asset_internal_group_key = SingleTweak(asset_raw_group_key, asset_id)</code> 
+* <code>asset_group_script_root</code> is a taproot that can hold arbitrary asset scripts enforcing conditions for minting the asset.
+
+and
+* <code>TapTweak</code> is the taproot tweak function as defined in [[../master/bip-0341.mediawiki|BIP-341]]. 
+* <code>SingleTweak</code> is a tweak function that unlike <code>TapTweak</code> uses an untagged hash: 
+<code>tweaked_pubkey = pubkey * sha256(tweak || pubkey) * G</code>
 
 The top level tree can be easily used to prove the existence of a set of given
 assets, the total amount of asset units held, as well as the sum of a given
@@ -517,7 +516,7 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 *** [<code>33*byte</code>:<code>pub_key</code>]
 * type: 10 (<code>asset_group_key</code>)
 ** value: 
-*** [<code>96*byte</code>:<code>pub_key || schnorr_sig</code>]
+*** [<code>32*byte</code>:<code>pub_key</code>]
 
 where:
 
@@ -536,12 +535,15 @@ where:
 *** If this type isn't present, then a <code>split_commitment</code> MUST be present.
 ** <code>split_commitment_proof</code>: is used to permit the spending of an asset UTXO created as a result of an asset split. When an asset is split, the non-change UTXO commits to the location of all other splits within an MS-SMT tree. When spending a change UTXO resulting from an asset_split, a normal <code>asset_witness</code> isn't required, instead the owner of the change asset UTXO must prove that it holds a valid split which was authorized by the main transfer transaction (the <code>root_asset</code>).
 *** Outputs with the same <code>split_commitment</code> are said to share a single <code>asset_witness</code> as such outputs are the result of a new asset split. Therefore we only need a single witness and the resulting merkle-sum asset tree to verify a transfer.
-** <code>asset_witness</code>: is a serialized witness in an identical format as Bitcoin's Segwit witness field. This field can only be blank if <code>prev_asset_input</code> is blank.
+** <code>asset_witness</code>: is a serialized witness in an identical format as Bitcoin's Segwit witness field. 
+*** If <code>prev_asset_input</code> is all zeroes, the witness will be either
+**** empty, to indicate this asset does not support further issuance. In this case <code>asset_group_key</code> MUST NOT be present.
+**** non-empty, in case the witness will be interpreted according to [[../master/bip-0340.mediawiki#specification|BIP-341]] validation rules using the <code>asset_group_key</code> in place of the <code>asset_script_key</code>. In this case <code>asset_group_key</code> MUST be present.
 * <code>split_commitment_root</code>: is used to commit to, and permit verification of the new output split distribution for normal assets. The <code>split_commitment_root</code> is an MS-SMT with a key of <code>sha256(output_index || asset_id || asset_script_key)</code>, and the value being the new Taproot Asset leaf. This is an optional field and is only specified when an asset value is split during transfer.
 *** Outputs with the same <code>split_commitment_root</code> are said to share a single <code>asset_witness</code> as such outputs are the result of a new asset split. Therefore we only need a single witness and the resulting merkle-sum asset tree to verify a transfer.
 * <code>asset_script_version</code>: is a 2 byte asset script version that governs how the following TLV value is to be validated.
 * <code>asset_script_key</code>: is the external public key derived in a BIP 341 manner which may commit to an asset script that encumbers this asset leaf.
-* <code>asset_group_key</code>: is a 32-byte public key as defined by [[../master/bip-0340.mediawiki|BIP-340]] followed by a 64-byte BIP 340 signature over the <code>asset_id</code>. This key can be used to associate distinct assets as identified by their <code>asset_id</code>, effectively allowing further issuance of a base asset. Assets that references the same <code>asset_group_key</code> are to be considered the same asset. This is an optional field, and assets that don't contain this field are effectively considered to be a one-time only issuance event, meaning no further assets related to the derived <code>asset_id</code> can be created.
+* <code>asset_group_key</code>: is a 32-byte public key as defined by [[../master/bip-0340.mediawiki|BIP-340]]. This key can be used to associate distinct assets as identified by their <code>asset_id</code>, effectively allowing further issuance of a base asset. Assets that references the same <code>asset_group_key</code> are to be considered the same asset. This is an optional field, and assets that don't contain this field are effectively considered to be a one-time only issuance event, meaning no further assets related to the derived <code>asset_id</code> can be created.
 * <code>canonical_universe</code>: is a key (with no corresponding value) which if specified, designates the existence of an on-chain canonical Universe. Specified further in [[./bip-tap-universe.mediawiki]], a canonical Universe is maintained by the issuer of an asset and can be used to allow 3rd parties to easily audit the total asset supply and also track future issuance. In short, if this is specified, ''second'' output of the next spend of the outpoint created during asset issuance MUST commit to the root hash of a base Universe and all subsequent spends must only happen after later asset issuance events, and MUST commit to a new valid Universe root. This feature allows light clients to watch a set of outputs on chain to be notified of future asset issuance.
 
 (TODO(roasbeef): merkle sum commitment over input set as well? enables probabilistic validation?)

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -507,8 +507,8 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 *** [<code>u16</code>:<code>num_inputs</code>][<code>asset_witnesses...</code>], where:
 **** [<code>...*byte</code>:<code>asset_witnesses</code>]:
 ***** [<code>asset_witness</code>]:
-****** type: 0 (<code>prev_asset_id</code>)
-******* value: [<code>prev_outpoint || asset_id || asset_script_key</code>]
+****** type: 0 (<code>prev_asset_input</code>)
+******* value: [<code>prev_outpoint || prev_asset_id || prev_asset_script_key</code>]
 ****** type: 1 (<code>asset_witness</code>)
 ******* value: [<code>...*byte</code>:<code>asset_witness</code>]
 ****** type: 2 (<code>split_commitment</code>)
@@ -537,14 +537,14 @@ where:
 * <code>lock_time</code>: is a field that restricts ''when'' an asset can be moved based on the included block height.
 * <code>relative_lock_time</code>: is a field that restricts ''when'' an asset can be moved based on a number of blocks that needs to passed from the mining of the outer transaction.
 * <code>prev_asset_witnesses</code>: is a ''nested'' TLV that contains the asset witnesses needed to verify the merging into the target asset leaf
-** <code>prev_asset_id</code>: references the previous asset input by the input position within the transaction, the asset ID of the previous asset tree, and the asset script hash.
+** <code>prev_asset_input</code>: references the previous asset input by the input position within the transaction, the asset ID of the previous asset tree, and the asset script hash.
 *** This value is included in any signatures generated within the asset witness itself, serving a purpose similar to the previous outpoint in vanilla Bitcoin.
 *** If this field is all zeroes, then that indicates a ''new'' asset is being created.
 *** For ''internal'' split verification, this field can be used to save space by including only a single signature/witness that covers all other new splits.
 *** If this type isn't present, then a <code>split_commitment</code> MUST be present.
 ** <code>split_commitment_proof</code>: is used to permit the spending of an asset UTXO created as a result of an asset split. When an asset is split, the non-change UTXO commits to the location of all other splits within an MS-SMT tree. When spending a change UTXO resulting from an asset_split, a normal <code>asset_witness</code> isn't required, instead the owner of the change asset UTXO must prove that it holds a valid split which was authorized by the main transfer transaction (the <code>root_asset</code>).
 *** Outputs with the same <code>split_commitment</code> are said to share a single <code>asset_witness</code> as such outputs are the result of a new asset split. Therefore we only need a single witness and the resulting merkle-sum asset tree to verify a transfer.
-** <code>asset_witness</code>: is a serialized witness in an identical format as Bitcoin's Segwit witness field. This field can only be blank if <code>prev_asset_id</code> is blank.
+** <code>asset_witness</code>: is a serialized witness in an identical format as Bitcoin's Segwit witness field. This field can only be blank if <code>prev_asset_input</code> is blank.
 * <code>split_commitment_root</code>: is used to commit to, and permit verification of the new output split distribution for normal assets. The <code>split_commitment_root</code> is an MS-SMT with a key of <code>sha256(output_index || asset_id || asset_script_key)</code>, and the value being the new Taproot Asset leaf. This is an optional field and is only specified when an asset value is split during transfer.
 *** Outputs with the same <code>split_commitment_root</code> are said to share a single <code>asset_witness</code> as such outputs are the result of a new asset split. Therefore we only need a single witness and the resulting merkle-sum asset tree to verify a transfer.
 * <code>asset_script_version</code>: is a 2 byte asset script version that governs how the following TLV value is to be validated.
@@ -783,7 +783,7 @@ Transfers are specified as follows:
 ## For each asset collection, ''i'' to be exchanged:
 ### The receiver creates a new asset script key commitment, <code>asset_script_key_i</code> (which will be used to delegate ownership of the input asset), and sends this to the owner.
 ### The owner takes the raw serialized asset script and closes a new asset witness over the <code>asset_script_key_i</code> script (as part of the serialized asset leaf). This witness is then transmitted to the receiver.
-### The receiver can now construct a new valid leaf (with a valid witness delegating ownership), either creating a new rooted asset tree (if they didn't own any instances of the asset collection lineage) or add it to an existing tree. Call this <code>asset_leaf_i</code>. This new leaf MUST properly reference a valid <code>prev_asset_id</code> to be a valid witness.
+### The receiver can now construct a new valid leaf (with a valid witness delegating ownership), either creating a new rooted asset tree (if they didn't own any instances of the asset collection lineage) or add it to an existing tree. Call this <code>asset_leaf_i</code>. This new leaf MUST properly reference a valid <code>prev_asset_input</code> to be a valid witness.
 # With internal transfer complete, the final external transfer is executed:
 ## The set of inputs (which may be heterogeneous w.r.t asset type) are added to a new version <code>2</code> Bitcoin transaction.
 ## The set of new ownership output are exchanged and added to the MIMO transfer transaction. Minimally each party MUST have a new ownership output present in the transaction.
@@ -810,8 +810,8 @@ assets owned by two parties, Alice and Bob:
 <source lang="python">
 verify_asset_input_proofs(asset_proofs: map[AssetPrevID]AssetLeafProof) -> bool
 
-    for prev_asset_id, asset_leaf in asset_proofs
-        prev_outpoint, asset_id, asset_script_key = prev_asset_id
+    for prev_asset_input, asset_leaf in asset_proofs
+        prev_outpoint, prev_asset_id, prev_asset_script_key = prev_asset_input
 
         match asset_leaf.proof_type:
             case FullProof:
@@ -831,22 +831,22 @@ verify_asset_input_proofs(asset_proofs: map[AssetPrevID]AssetLeafProof) -> bool
                         fail
 
             case CompactProof:
-                if not verify_universe_proof(asset_leaf.inclusion_proofs, asset_id):
+                if not verify_universe_proof(asset_leaf.inclusion_proofs, prev_asset_id):
                     fail
 
 transfer_assets(sender_assets: map[AssetID]AssetLeaf, 
     receiver_scripts: [[32]byte]) -> map[AssetID]AssetLeaf
 
     new_assets = {}
-    for prev_asset_id, asset_leaf in sender_assets:
+    for prev_asset_input, asset_leaf in sender_assets:
         asset_script_key = asset_script_keyes[i]
 
         new_leaf = clone_unique_leaf(asset_leaf)
         new_leaf.asset_script_key = asset_script_key
-        new_leaf.prev_asset_id = prev_asset_id
+        new_leaf.prev_asset_input = prev_asset_input
         new_leaf.asset_witness = gen_witness(tlv_encode(new_leaf))
 
-        new_assets[prev_asset_id.asset_id] = new_leaf
+        new_assets[prev_asset_input.prev_asset_id] = new_leaf
 
     return new_assets
 
@@ -870,8 +870,8 @@ taproot_asset_interactive_transfer(bob_inputs_assets: map[AssetID]AssetLeafProof
       fail
 
     transfer_tx = new_tx()
-    for prev_asset_id, _ in list(chain(alice_input_assets, bob_inputs_assets)):
-        transfer_tx.add_txin(prev_asset_id.prev_outpoint)
+    for prev_asset_input, _ in list(chain(alice_input_assets, bob_inputs_assets)):
+        transfer_tx.add_txin(prev_asset_input.prev_outpoint)
 
     transfer_tx.add_output(taproot_output_script(key=alice_internal_key, leaves=[alice_new_taproot_asset_root]))
     transfer_tx.add_output(taproot_output_script(key=bob_internal_key, leaves=[bob_new_taproot_asset_root]))
@@ -971,7 +971,7 @@ units of asset ''Y'', using Taproot Asset address ''C'':
 * Alice constructs a new sub-commitment in her asset tree that now instead commits to <code>T-N</code> units of the asset (in the case of a normal asset).
 * Alice signs and broadcasts a new transaction including the two outputs, with a necessary deposit amount of ''K'' satoshis.
 
-Alices internal transfer doesn't include a <code>prev_asset_id</code> nor asset
+Alices internal transfer doesn't include a <code>prev_asset_input</code> nor asset
 witness for Bob's new asset leaf. Instead, Bob will use the referenced
 <code>split_commitment_root</code> to create a
 <code>split_commitment_proof</code> that asserts the existence of the new split

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -480,16 +480,9 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 * type: 0 (<code>taproot_asset_version</code>)
 ** value: 
 *** [<code>u8</code>:<code>version</code>]
-* type: 1 (<code>asset_genesis</code>)
+* type: 1 (<code>asset_id</code>)
 ** value:
-*** [<code>32*byte</code>:<code>first_prev_out_hash</code>]
-*** [<code>u32</code>:<code>first_prev_out_index</code>]
-*** [<code>BigSize</code>:<code>tag_len</code>]
-*** [<code>tag_len*byte</code>:<code>tag</code>]
-*** [<code>BigSize</code>:<code>metadata_len</code>]
-*** [<code>metadata_len*byte</code>:<code>metadata</code>]
-*** [<code>u32</code>:<code>output_index</code>]
-*** [<code>u8</code>:<code>type</code>]
+*** [<code>32*byte</code>:<code>asset_id</code>]
 * type: 2 (<code>asset_type</code>)
 ** value: 
 *** [<code>u8</code>:<code>type</code>]
@@ -529,7 +522,6 @@ An asset leaf is a serialized TLV blob, with the following key-value mappings:
 where:
 
 * <code>taproot_asset_version</code>: is a single byte that denotes the version of Taproot Asset being used, which allows a client to determine which of the below TLV values to expect.
-* <code>asset_genesis</code>: is the <code>asset_genesis</code> defined above, representing the preimage of the <code>asset_id</code>.
 * <code>asset_type</code>: is a single byte representing the type of the asset, two starting asset types are defined:
 ** <code>0</code>: a normal asset
 ** <code>1</code>: a collectible asset


### PR DESCRIPTION
This PR adds changes the group key derivation to rely on a `asset_raw_key` and `asset_script_root` provided in the asset proof at genesis. This lets the verifier derive and verify the `asset_group_key`.

TODO:
- [x] Require `raw_key` to be provided with proof at genesis.
- [x] Verify minting signature against group key.
- [x] Provide valid witness against group key when minting.

~~It also renames all occurrences of `asset_family_key` to `asset_group_key`.~~ Builds on #35 

See https://github.com/lightninglabs/taro/issues/91