### PR TITLE
bip-taro: remove asset meta from asset TLV, replace with meta_hash

### DIFF
--- a/bip-taro-addr.mediawiki
+++ b/bip-taro-addr.mediawiki
@@ -67,8 +67,7 @@ types:
 *** [<code>u32</code>:<code>first_prev_out_index</code>]
 *** [<code>BigSize</code>:<code>tag_len</code>]
 *** [<code>tag_len*byte</code>:<code>tag</code>]
-*** [<code>BigSize</code>:<code>metadata_len</code>]
-*** [<code>metadata_len*byte</code>:<code>metadata</code>]
+*** [<code>32*byte</code>:<code>meta_hash</code>]
 *** [<code>u32</code>:<code>output_index</code>]
 *** [<code>u8</code>:<code>type</code>]
 * type: 3 (<code>asset_key_family</code>)

--- a/bip-taro-proof-file.mediawiki
+++ b/bip-taro-proof-file.mediawiki
@@ -114,7 +114,14 @@ blob with the following format:
 * type: 7 (<code>split_root_proof</code>)
 ** value:
 *** [<code>...*byte</code>:<code>taro_taproot_proof</code>]
-* type: 8 (<code>taro_input_splits</code>)
+* type: 8 (<code>meta_reveal</code>)
+** value:
+*** [<code>...*byte</code>:<code>asset_meta_reveal</code>]
+**** type: 0 (<code>meta_type</code>
+***** value: [<code>uint8</code>:<code>type</code>]
+**** type: 1 (<code>meta_data</code>
+***** value: [<code>*byte</code>:<code>meta_data_bytes</code>]
+* type: 9 (<code>taro_input_splits</code>)
 ** value:
 *** [<code>...*byte</code>:<code>nested_proof_map</code>]
 
@@ -132,6 +139,13 @@ where:
 * <code>taproot_exclusion_proofs</code>: is a series of _exclusion_ proofs that prove that the other outputs in a transaction don't commit to a valid taro asset. This re-uses the <code>taro_taproot_proof</code> structure, but will only contain an <code>taro_commitment_exclusion_proof</code> value and not also a <code>taro_taproot_proof</code> value.
 * <code>split_root_proof</code>: is an optional <code>taro_taproot_proof</code> that proves the inclusion of the split commitment's root asset in case of an asset split.
 * <code>taro_input_splits</code>: is an optional list of nested full proofs for any additional inputs found within the resulting asset.
+* <code>asset_meta_reveal</code>: is an mandatory field (for genesis assets) that reveals the pre-image of the <code>asset_meta_hash</code> contained in the asset TLV.
+** The <code>meta_type</code> field can be used to indicate how to parse/render the meta data pre-image.
+*** The meta type currently defined are:
+**** <code>0</code>: no true type, just desginates an opaque data blob.
+** The <code>meta_data</code> is the raw meta data itself.
+*** If the contained asset is a genesis asset (has a valid genesis witness), then a verifier SHOULD verify that: `sha256(tlv_encode(meta_reveal)) == asset_meta_hash`.
+*** This field MUST only be present for genesis asset proofs.
 
 The final flat proof file has the following format:
 * [<code>u32</code>:<code>file_version</code>] version of proof file
@@ -167,6 +181,7 @@ Given a proof file for a given asset <code>f_proof</code>, genesis outpoint
 ## Verify that the asset witness included at the <code>prev_asset_witness<code> field of the <code>taro_asset_leaf</code> is valid based on the specific <code>asset_script_version</code>
 ## If a <code>split_commitment_opening</code> is present, verify that the included leaf is a valid opening rooted at the <code>taro_asset_leaf</code>'s <code>split_commitment_root</code> field.
 ## If a <code>split_commitment_opening</code> is present, verify that an inclusion proof for the <code>split_commitment_root</code>'s leaf is present in <code>split_root_proof</code>.
+## If the asset is a genesis asset, and the <code>asset_meta</code> field is present, then verify that <code>sha256(asset_meta) == asset.asset_meta_hash</code>
 
 A psuedo-code routine for flat file verification follows:
 <source lang="python">
@@ -221,6 +236,24 @@ verify_asset_file_proof(file_proof []byte, genesis_outpoint OutPoint,
                 proof_tlv_map.split_commitment_opening.split_commitment_root,
                 proof_tlv_map.split_root_proof,
             ):
+                return false
+
+        has_meta_reveal = proof_tlv_map.meta_reveal is not None
+        has_meta_hash = proof_tlv_map.asset.meta_hash is not None
+        is_genesis_asset = is_genesis_asset(proof_tlv_map.asset)
+        match:
+            case has_meta_reveal && !is_genesis_asset:
+                return false
+
+            case has_meta_reveal && is_genesis_asset:
+                meta_hash := sha256(meta_reveal)
+                if meta_hash != proof_tlv_map.asset.meta_hash:
+                    return false
+
+            case has_meta_hash && is_genesis_asset && !has_meta_reveal:
+                return false
+
+            case !has_meta_reveal && is_genesis_asset:
                 return false
 
     return true

--- a/bip-taro.mediawiki
+++ b/bip-taro.mediawiki
@@ -225,12 +225,13 @@ Taro-specific commitments, then the same or different leaf version can be used
 to gate verification of the new behavior.
 
 An <code>asset_id</code> is the 32-byte hash of: 
-* <code>sha256(genesis_outpoint || asset_tag || asset_meta || output_index || asset_type)</code>
+* <code>sha256(genesis_outpoint || sha256(asset_tag) || asset_meta_hash || output_index || asset_type)</code>
 
 where:
 * <code>genesis_outpoint</code> is the first previous input outpoint used in the asset genesis transaction serialized in Bitcoin wire format.
 * <code>asset_tag</code> is a random 32-byte value that represents a given asset, and can be used to link a series of discrete assets into a single asset family. In practice, this will typically be the hash of a human readable asset name.
-* <code>asset_meta</code> is an opaque 32-byte value that can be used to commit to various metadata including external links, documents, stats, attributes, images, etc. Importantly, this field is considered to be ''immutable''.
+* <code>asset_meta_hash</code> is an opaque 32-byte value that can be used to commit to various metadata including external links, documents, stats, attributes, images, etc. Importantly, this field is considered to be ''immutable''.
+** The genesis asset proof MUST contain the preimage of the <code>asset_meta_hash</code>, which allows verifiers to obtain the committed data and also verify the sha2 preimage.
 * <code>output_index</code> (4 byte, big-endian) is the index  of the output which contains the unique Taro commitment in the genesis transaction. 
 * <code>asset_type</code> (1 byte) is the type of the asset being minted.
 
@@ -373,8 +374,11 @@ hash) is described in <code>bip-taro-taproot-merkle-tree.mediawiki</code>.
 
 The <code>asset_tag</code> field cannot be enforced to be ''globally'' unique.
 Instead to ensure locally unique <code>asset_id</code> instances within initial
-asset creation, each <code>asset_tag</code> and <code>asset_meta</code> value
-MUST only appear once during asset creation.
+asset creation, each <code>asset_tag</code> and <code>asset_meta_hash</code>
+value MUST only appear once during asset creation. In addition, the _pre image_
+to the <code>asset_meta_hash</code>, dubbed the <code>meta_reveal</code> can be
+packaged along with the initial proof of genesis asset creation to ensure
+verifiers can obtain all the relevant data for a given asset.
 
 The top-level MS-SMT commits to the set of all held defined assets. The root hash
 of this MS-SMT tree is referred to as the <code>asset_tree_root</code>. The
@@ -567,9 +571,7 @@ iterations. Types with a numerical value above this reserved range can be used
 to store arbitrary attributes to assets. An eaxmple of such an attribute would
 be storing the _mutable_ stats of an in-game asset.  Any immutable fields for
 normal or collectible assets should be instead committed to within the
-`asset_meta` be storing the ''mutable'' stats of an in-game asset. Any
-immutable fields for normal or unique assets should be instead committed to
-within the <code>asset_meta</code> field.
+`asset_meta_hash` be storing the ''mutable'' stats of an in-game asset. 
 
 The usage of an MS-SMT for the Taro asset tree itself permits parties to easily
 verify that no new assets are created when inputs are referenced, and also that
@@ -592,11 +594,12 @@ The following function creates a new valid taproot public key script whose
 internal tapscript tree commits to the representation of the new asset:
 <source lang="python">
 create_new_asset_output(total_units: uint64, asset_tag: [32]byte, 
-    genesis_point: [36]byte, asset_meta: [32]byte, output_index uint32,
+    genesis_point: [36]byte, asset_meta_hash: [32]byte, output_index uint32,
     asset_type: uint8, asset_script_key: [32]byte, taro_attrs: TLV) -> PkScript:
 
     asset_id = sha256(
-        genesis_point || asset_tag || asset_meta || output_index || asset_type
+        genesis_point || sha256(asset_tag) || asset_meta_hash || output_index || 
+        asset_type
     )
 
     tlv_leaf = new_taro_tlv_leaf(


### PR DESCRIPTION
In this commit, we modify the way the asset meta functions within the protocol. Rather than have the asset meta live within _each_ instance of the asset within the context of a series of proofs. We instead commit to the asset meta itself in the form of a `meta_hash`. This meta hash can then be optionally revealed within the proof for the given genesis asset, we call this the `meta_reveal`.

The `meta_reveal` itself is another nested TLV instance. Verifiers of an asset genesis proof that verify that the TLV encoding of the meta reveal matches the `meta_hash` within the genesis asset.

The `meta_reveal` has two currently defined fields: the type, and the data itself. Today the type is just `0`, which just means it's an opaque blob. In the future, further types can be added that inform clients or UIs how to parse, render, and interact with the meta.