### PR TITLE
bip-tap-proof-file: add version

### DIFF
--- a/bip-tap-proof-file.mediawiki
+++ b/bip-tap-proof-file.mediawiki
@@ -64,22 +64,25 @@ its the genesis outpoint.
 
 A single inclusion and state transition proof has the following format is a TLV
 blob with the following format:
-* type: 0 (<code>prev_out</code>)
+* type: 0 (<code>version</code>)
+** value:
+*** [<code>uint32</code>:<code>version</code>]
+* type: 1 (<code>prev_out</code>)
 ** value: 
 *** [<code>36*byte</code>:<code>txid || output_index</code>]
-* type: 1 (<code>block_header</code>)
+* type: 2 (<code>block_header</code>)
 ** value: 
 *** [<code>80*byte</code>:<code>bitcoin_header</code>]
-* type: 2 (<code>anchor_tx</code>)
+* type: 3 (<code>anchor_tx</code>)
 ** value: 
 *** [<code>...*byte</code>:<code>serialized_bitcoin_tx</code>]
-* type: 3 (<code>anchor_tx_merkle_proof</code>)
+* type: 4 (<code>anchor_tx_merkle_proof</code>)
 ** value: 
 *** [<code>...*byte</code>:<code>merkle_inclusion_proof</code>]
-* type: 4 (<code>taproot_asset_asset_leaf</code>)
+* type: 5 (<code>taproot_asset_asset_leaf</code>)
 ** value: 
 *** [<code>tlv_blob</code>:<code>serialized_tlv_leaf</code>]
-* type: 5 (<code>taproot_asset_inclusion_proofs</code>)
+* type: 6 (<code>taproot_asset_inclusion_proofs</code>)
 ** value: 
 *** [<code>...*byte</code>:<code>taproot_asset_taproot_proof</code>]
 **** type: 0 (<code>output_index</code>
@@ -110,30 +113,31 @@ blob with the following format:
 ******* value: [<code>...*byte</code>:<code>tapscript_preimage</code>]
 ****** type: 1 (<code>tap_image_2</code>)
 ******* value: [<code>...*byte</code>:<code>tapscript_preimage</code>]
-* type: 6 (<code>taproot_exclusion_proofs</code>)
+* type: 7 (<code>taproot_exclusion_proofs</code>)
 ** value: 
 *** [<code>uint16</code>:<code>num_proofs</code>][<code>...*byte</code>:<code>taproot_asset_taproot_proof</code>]
-* type: 7 (<code>split_root_proof</code>)
+* type: 8 (<code>split_root_proof</code>)
 ** value:
 *** [<code>...*byte</code>:<code>taproot_asset_taproot_proof</code>]
-* type: 8 (<code>meta_reveal</code>)
+* type: 9 (<code>meta_reveal</code>)
 ** value:
 *** [<code>...*byte</code>:<code>asset_meta_reveal</code>]
 **** type: 0 (<code>meta_type</code>
 ***** value: [<code>uint8</code>:<code>type</code>]
 **** type: 1 (<code>meta_data</code>
 ***** value: [<code>*byte</code>:<code>meta_data_bytes</code>]
-* type: 9 (<code>taproot_asset_input_splits</code>)
+* type: 10 (<code>taproot_asset_input_splits</code>)
 ** value:
 *** [<code>...*byte</code>:<code>nested_proof_map</code>]
-* type: 10 (<code>challenge_witness</code>)
+* type: 11 (<code>challenge_witness</code>)
 ** value:
 *** [<code>...*byte</code>:<code>challenge_witness</code>]
-* type: 11 (<code>block_height</code>)
+* type: 12 (<code>block_height</code>)
 ** value:
 *** [<code>uint32</code>:<code>block_height</code>]
 
 where:
+* <code>version</code>: is the version of the single mint or transition proof, currently fixed to value <code>0</code>.
 * <code>prev_out</code>: is the 36-byte outpoint of the Taproot Asset committed output being spent. If this is the very first proof, then this value will be the "genesis outpoint" for the given asset.
 * <code>block_header</code>: is the 80-byte block header that includes a spend of the above outpoint.
 * <code>merkle_inclusion_proof</code>: is the merkle inclusion proof of the transaction spending the <code>previous_outpoint</code>. This is serialized with a <code>BigSize</code> length prefix as:
@@ -158,7 +162,7 @@ where:
 * <code>block_height</code>: is the block height of the block that includes a spend of the <code>prev_out</code> outpoint.
 
 The final flat proof file has the following format:
-* [<code>u32</code>:<code>file_version</code>] version of proof file
+* [<code>u32</code>:<code>file_version</code>] version of proof file format, currently fixed to <code>0</code>.
 * [<code>BigSize</code>:<code>num_proofs</code>] number of proofs contained in the file
 * [<code>num_proof*proof</code>:<code>proofs</code>] encoded proofs
 ** [<code>BigSize</code>:<code>proof_len</code>] length of encoded proof


### PR DESCRIPTION
Introduces a version number for an individual mint or transition proof, not just the whole file.