### PR TITLE
bip-tap-psbt: define value for asset version

### DIFF
--- a/bip-tap-psbt.mediawiki
+++ b/bip-tap-psbt.mediawiki
@@ -375,6 +375,13 @@ split asset is encoded in TLV format as defined in
 | The preimage of the tapscript sibling that is on the same level as the Taproot
 Asset commitment that was committed to in the anchor. If this is not present,
 then the Taproot Asset commitment is the only script leaf in the tree.
+|-
+| Taproot Asset Version
+| <tt>PSBT_OUT_TAP_ASSET_VERSION = 0x79</tt>
+| None
+| No key data
+| <tt><uint8></tt>
+| The asset version to be used for the specified TAP output.
 |}
 
 ===Values for <tt>PSBT_OUT_TAP_TYPE</tt>===


### PR DESCRIPTION
Using this, the vPSBT packet now contains the information required to have a distinct asset version for a given output.