### PR TITLE
bip-tap-proof-file: add new JSON meta type

### DIFF
--- a/bip-tap-proof-file.mediawiki
+++ b/bip-tap-proof-file.mediawiki
@@ -169,6 +169,7 @@ where:
 ** The <code>meta_type</code> field can be used to indicate how to parse/render the meta data pre-image.
 *** The meta type currently defined are:
 **** <code>0</code>: no true type, just designates an opaque data blob.
+**** <code>1</code>: a generic JSON blob, MUST be valid JSON.
 ** The <code>meta_data</code> is the raw meta data itself.
 *** If the contained asset is a genesis asset (has a valid genesis witness), then a verifier SHOULD verify that: `sha256(tlv_encode(meta_reveal)) == asset_meta_hash`.
 *** This field MUST only be present for genesis asset proofs.


### PR DESCRIPTION
In this commit, we add a new JSON meta type. This is to be used by developers to specify key-value meta data pairs in a manner more friendly than the lower level TLV serialization.

This has been implemented in:
https://github.com/lightninglabs/taproot-assets/pull/794