### PR TITLE
bip-tap: correct `asset_tree_root` usage

### DIFF
--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -212,7 +212,7 @@ asset ID. A given Taproot Asset tree is composed of two nested MS-SMT instances:
 
 The root hash of an asset tree, observing [[../master/bip-0341.mediawiki|BIP-341]] is
 represented as a Tapscript tree that commits to a single unique leaf of:
-* <code>tagged_hash("TapLeaf", leaf_version || taproot_asset_marker || asset_tree_root || sum_value)</code>
+* <code>tagged_hash("TapLeaf", leaf_version || taproot_asset_marker || taproot_asset_version || asset_tree_root || sum_value)</code>
 
 where:
 * <code>taproot_asset_marker</code> is the <code>sha256</code> hash of the ascii string "taproot-assets".

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -212,12 +212,13 @@ asset ID. A given Taproot Asset tree is composed of two nested MS-SMT instances:
 
 The root hash of an asset tree, observing [[../master/bip-0341.mediawiki|BIP-341]] is
 represented as a Tapscript tree that commits to a single unique leaf of:
-* <code>tagged_hash("TapLeaf", leaf_version || taproot_asset_marker || taproot_asset_version || asset_tree_root)</code>
+* <code>tagged_hash("TapLeaf", leaf_version || taproot_asset_marker || asset_tree_root || sum_value)</code>
 
 where:
 * <code>taproot_asset_marker</code> is the <code>sha256</code> hash of the ascii string "taproot-assets".
 * <code>taproot_asset_version</code> is the version of the Taproot Assets system which defines how the remainder of the commitment value is to be interpreted.
-* <code>asset_tree_root</code> is a 40 byte (32 byte for hash, 8 bytes for value) MS-SMT root.
+* <code>asset_tree_root</code> is the 32-byte <code>sha256</code> root hash of the asset tree.
+* <code>sum_value</code> is the 8-byte sum of the <code>amt</code> values of each of the asset leaves.
 
 
 A <code>leaf_version</code> of ??? is selected. From the PoV of the Bitcoin
@@ -438,7 +439,7 @@ tranches of the same asset) or collectibles.
 * <code>asset_id</code> is the 32-byte asset ID specified above
 * <code>left_hash</code> is the hash of the left sub-tree.
 * <code>right_hash</code> is the hash of the right sub-tree.
-* <code>amt_sum</code> is the sum of the <code>amt</code> values of each of the asset leaves (essentially asset UTXOs).
+* <code>sum_value</code> is the sum of the <code>amt</code> values of each of the asset leaves (essentially asset UTXOs).
 
 Committing to the total sum of the asset values in a given asset sub-tree for a
 given asset allows asset holders to easily prove how much of a given asset they

--- a/bip-tap.mediawiki
+++ b/bip-tap.mediawiki
@@ -215,7 +215,7 @@ represented as a Tapscript tree that commits to a single unique leaf of:
 * <code>tagged_hash("TapLeaf", leaf_version || taproot_asset_marker || taproot_asset_version || asset_tree_root || sum_value)</code>
 
 where:
-* <code>taproot_asset_marker</code> is the <code>sha256</code> hash of the ascii string "taproot-assets".
+* <code>taproot_asset_marker</code> is the <code>sha256</code> hash of the ascii string "taproot-assets:194243".
 * <code>taproot_asset_version</code> is the version of the Taproot Assets system which defines how the remainder of the commitment value is to be interpreted.
 * <code>asset_tree_root</code> is the 32-byte <code>sha256</code> root hash of the asset tree.
 * <code>sum_value</code> is the 8-byte sum of the <code>amt</code> values of each of the asset leaves.


### PR DESCRIPTION
The field `asset_tree_root` is not 40 bytes long, but 32.

This is both consistent with the implementation, and with the definition
of the field further down in this bip.

Definition:

> the asset tree is calculated as either:
> * <code>asset_tree_root = sha256(asset_id || left_hash || right_hash
> || sum_value)</code>
> or
> * <code>asset_tree_root = sha256(asset_group_key || left_hash ||
> right_hash || sum_value)</code>

Implementation:

```
leafParts := [][]byte{
  {byte(c.Version)}, TaprootAssetsMarker[:], rootHash[:],
  rootSum[:],
}
```

The bip now reflects this.